### PR TITLE
👨‍🔬 PoC to graph entire project

### DIFF
--- a/lib/code_vis.ex
+++ b/lib/code_vis.ex
@@ -65,4 +65,12 @@ defmodule CodeVis do
         end
     end
   end
+
+  @spec build_mega_adjacency_map([module()]) :: adjacency_map()
+  def build_mega_adjacency_map(user_modules \\ CodeVis.ProjectAnalysis.user_modules()) do
+    Repo.get_fuctions_by_module()
+    |> Map.values()
+    |> Enum.flat_map(fn x -> x end)
+    |> Enum.reduce(%{}, fn mfa, acc -> build_adjacency_map(acc, mfa, user_modules) end)
+  end
 end

--- a/lib/code_vis/plug/visualize.ex
+++ b/lib/code_vis/plug/visualize.ex
@@ -46,6 +46,21 @@ defmodule CodeVis.Plug.Visualize do
     |> rendered(conn)
   end
 
+  defp render_mega_graph(conn, mfa \\ {Fake, :fxn, 0}) do
+    map = CodeVis.build_mega_adjacency_map()
+
+    dot_string =
+      map
+      |> Display.GraphIt.new()
+      |> Display.GraphIt.to_string()
+
+    assigns = %{dot_string: dot_string, mfa: mfa}
+
+    assigns
+    |> graph()
+    |> rendered(conn)
+  end
+
   @spec rendered(String.t(), Plug.Conn.t()) :: Plug.Conn.t()
   defp rendered(html, conn) do
     conn
@@ -72,6 +87,9 @@ defmodule CodeVis.Plug.Visualize do
 
   def call(conn, _opts) do
     case get_query_params_mfa(conn) do
+      {:ok, {Fake, :fxn, 0}} ->
+        render_mega_graph(conn)
+
       {:ok, mfa} ->
         render_graph(conn, mfa)
 

--- a/lib/display/graph_it.ex
+++ b/lib/display/graph_it.ex
@@ -26,6 +26,21 @@ defmodule Display.GraphIt do
     graph
   end
 
+  # run through each key, traversing all of their children and adding to the graph & updating the map
+  @spec new(CodeVis.adjacency_map()) :: Graphvix.Graph.t()
+  def new(map) do
+    {map_with_vertex_ids, graph} =
+      map
+      |> Map.keys()
+      |> Enum.reduce({map, Graph.new()}, fn mfa, {updated_map, updated_graph} ->
+        IO.puts("About to traverse mfa: #{inspect(mfa)}")
+        add_node(updated_map, mfa, nil, updated_graph)
+      end)
+
+    IO.inspect(map_with_vertex_ids, label: "Final Map")
+    graph
+  end
+
   @spec to_file(Graphvix.Graph.t(), String.t()) :: :ok
   def to_file(graph, file_name \\ "_graphs/first_graph"), do: Graph.compile(graph, file_name)
 
@@ -79,9 +94,12 @@ defmodule Display.GraphIt do
           nil | any()
         ) ::
           {Graphvix.Graph.t(), vertex_id :: any()}
-  defp add_node_and_edge_to_parent(graph, mfa, nil) do
+  defp add_node_and_edge_to_parent(graph, {_, _, _} = mfa, nil) do
     Graph.add_vertex(graph, Display.format_mfa(mfa))
   end
+
+  # Node already exists and it's a root, move on
+  defp add_node_and_edge_to_parent(graph, current_vertex_id, nil), do: {graph, current_vertex_id}
 
   defp add_node_and_edge_to_parent(graph, {_, _, _} = mfa, parent_vertex_id) do
     {updated_graph, current_vertex_id} = Graph.add_vertex(graph, Display.format_mfa(mfa))

--- a/test_project/lib/test_project.ex
+++ b/test_project/lib/test_project.ex
@@ -25,3 +25,18 @@ defmodule TestProject do
     defp local_remote, do: TestProject.ModuleA.fxn()
   end
 end
+
+defmodule SideTree do
+  def fxn do
+    SideTree.One.fxn()
+    SideTree.Two.fxn()
+  end
+
+  defmodule One do
+    def fxn, do: 4
+  end
+
+  defmodule Two do
+    def fxn, do: 4
+  end
+end


### PR DESCRIPTION
Proves it can graph multiple trees at once

`localhost:1337?mfa=Fake.fxn/0` -> url leads to 1 off functions for graphing everything

* Code needs to be reworked
* Tests simplified
* url changed to something reasonable
* Do I need the intermediate map stage for this one? Will it crush memory-wise?
* Do I ever need to traverse the Intermediate form recursively down the children or can I just `Enum.map/2`
  * At each result. Draw a node if it doesn't already exist.
  * Can't draw edges until Children are drawn, so that means edges can only be drawn to parents
    * Or I do it in 2 passes. Draw all of the nodes from the map (reduce on `{Map, Graph}`)
    * Then do a second pass to draw all of the edges

This could be useful - Roots are obvious and meaningful. We can do global analysis

<img width="1665" alt="MultiTreeGraph" src="https://user-images.githubusercontent.com/8139629/108612963-0121c100-73bb-11eb-973b-f63281b880cc.png">
